### PR TITLE
Ejemplo: Proporción, corrección previa en código 

### DIFF
--- a/notas/01-montecarlo.org
+++ b/notas/01-montecarlo.org
@@ -183,7 +183,7 @@ inicial es $p(\theta) = 2\theta$ (~checa que es una densidad~).
   crear_log_post <- function(n, k){
     function(theta){
       verosim <- k * log(theta) + (n - k) * log(1 - theta)
-      inicial <- log(theta)
+      inicial <- log(2) + log(theta)
       verosim + inicial
     }
   }

--- a/rscripts/01-montecarlo.R
+++ b/rscripts/01-montecarlo.R
@@ -63,7 +63,7 @@ norm.cuadrature |>
 crear_log_post <- function(n, k){
   function(theta){
     verosim <- k * log(theta) + (n - k) * log(1 - theta)
-    inicial <- log(theta)
+    inicial <- log(2) + log(theta)
     verosim + inicial
   }
 }


### PR DESCRIPTION
La dist.  inicial está indicada como $p(\theta) = 2\theta$ pero en el código se consideró únicamente como $\theta$, por lo que se agrega la actualización.